### PR TITLE
Merge Skip Device Slider Potentiometers Into Skip Device Main

### DIFF
--- a/Skip-Device/.vscode/tasks.json
+++ b/Skip-Device/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "PlatformIO",
+			"task": "Pre-Debug (lolin32)",
+			"problemMatcher": [
+				"$platformio"
+			],
+			"label": "PlatformIO: Pre-Debug (lolin32)"
+		}
+	]
+}

--- a/Skip-Device/include/slidePotentiometersDriver.h
+++ b/Skip-Device/include/slidePotentiometersDriver.h
@@ -1,0 +1,17 @@
+/**
+ * @file slidePotentiometersDriver.h
+ * @author Graham Driver (drivergraham1@gmail.com)
+ * @brief This script contains functions to initialize and control the slide potentiometers connected to the WEE Curl Skip Device.
+ * @version 0.1
+ * @date 2024-02-18
+ * 
+ * @copyright Copyright (c) 2024
+ * 
+ */
+#include <Arduino.h>
+#include <stdint.h>
+
+#define leftSlidePin    A0
+#define rightSlidePin   A99
+
+uint8_t getRawADCLeftPotentiometer();

--- a/Skip-Device/include/slidePotentiometersDriver.h
+++ b/Skip-Device/include/slidePotentiometersDriver.h
@@ -1,17 +1,59 @@
 /**
  * @file slidePotentiometersDriver.h
- * @author Graham Driver (drivergraham1@gmail.com)
- * @brief This script contains functions to initialize and control the slide potentiometers connected to the WEE Curl Skip Device.
- * @version 0.1
+ * @author Graham Driver (driverg@myumanitoba.ca)
+ * @brief header file for the slider drivers.
+ * @version 0.2
  * @date 2024-02-18
  * 
  * @copyright Copyright (c) 2024
  * 
  */
 #include <Arduino.h>
-#include <stdint.h>
+#include <stdlib.h>
 
-#define leftSlidePin    A0
-#define rightSlidePin   A99
+#define RAWindowSize    100
+#define leftSliderPin   A0
+#define rightSliderPin  A13
 
-uint8_t getRawADCLeftPotentiometer();
+typedef struct{
+    uint8_t index = 0;            // Index of the moving average
+    uint16_t data[RAWindowSize];  // Data from rolling average
+    uint32_t avgSum = 0;          // Sum of values in data
+    uint16_t pin = INT16_MAX;     // Pin of the slider
+}slider_t;
+
+typedef enum
+{
+  // Status Types (Optional to use)
+  SLIDE_POT_OK       = 0x00,  
+  SLIDE_POT_ERROR    = 0x01,
+  SLIDE_POT_BUSY     = 0x02,
+  SLIDE_POT_TIMEOUT  = 0x03
+} SLIDE_POT_StatusTypeDef;
+
+
+/**
+ * @brief This function can be called to poll the analog signal from the given slider.
+ * Should be passed slider_t type that will keep moving average of signal.
+ * 
+ * @param slider A slider struct pointer.
+ * @return SLIDE_POT_StatusTypeDef 
+ */
+SLIDE_POT_StatusTypeDef pollSlider(slider_t *slider);
+
+
+/**
+ * @brief Get the Average Pot Value
+ * 
+ * @param slider A slider struct pointer.
+ * @return uint16_t 
+ */
+uint16_t getAveragePotValue(slider_t *slider);
+
+/**
+ * @brief Get the Percentage Pot Value
+ * 
+ * @param slider A slider struct pointer.
+ * @return uint8_t
+ */
+uint8_t getPercentagePotValue(slider_t *slider);

--- a/Skip-Device/platformio.ini
+++ b/Skip-Device/platformio.ini
@@ -12,3 +12,4 @@
 platform = espressif32
 board = lolin32
 framework = arduino
+debug_tool = esp-prog

--- a/Skip-Device/platformio.ini
+++ b/Skip-Device/platformio.ini
@@ -12,4 +12,4 @@
 platform = espressif32
 board = lolin32
 framework = arduino
-debug_tool = esp-prog
+upload_protocol = esptool

--- a/Skip-Device/src/main.cpp
+++ b/Skip-Device/src/main.cpp
@@ -29,9 +29,13 @@ void setup() {
 }
 
 void loop() {
-  //polling loop
+  //Slider polling loop
+
+  // Make sure sliders are constantly polled
   pollSlider(&leftSlider);
   pollSlider(&rightSlider);
+
+  // Every 100ms get the value of the pots
   if((millis() - lastmilis) > 100){
     leftAverage = getAveragePotValue(&leftSlider);
     rightAverage = getAveragePotValue(&rightSlider);

--- a/Skip-Device/src/main.cpp
+++ b/Skip-Device/src/main.cpp
@@ -13,9 +13,12 @@
 #include <Arduino.h>
 #include "slidePotentiometersDriver.h"
 
-u_long lastmilis;
+// Slider Structs
 slider_t leftSlider;
 slider_t rightSlider;
+
+// Variables
+u_long lastmilis;
 uint16_t leftAverage;
 uint16_t rightAverage;
 uint8_t leftPercentage;
@@ -29,8 +32,10 @@ void setup() {
 }
 
 void loop() {
-  //Slider polling loop
+  // main loop
 
+
+  // Slider polling Section
   // Make sure sliders are constantly polled
   pollSlider(&leftSlider);
   pollSlider(&rightSlider);
@@ -44,5 +49,5 @@ void loop() {
     Serial.printf("Left Pot Value: %d, Left Pot Percentage: %d, Right Pot Value: %d, Right Pot Percentage: %d", leftAverage, leftPercentage, rightAverage, rightPercentage);
     lastmilis = millis();
   }
-  
+  // End of Slider polling Section
 }

--- a/Skip-Device/src/main.cpp
+++ b/Skip-Device/src/main.cpp
@@ -1,18 +1,42 @@
 #include <Arduino.h>
+#include "slidePotentiometersDriver.h"
 
-// put function declarations here:
-int myFunction(int, int);
+#define RAWindowSize    50
+
+typedef struct{
+  uint8_t index;
+  uint8_t data[RAWindowSize];
+  uint32_t avgSum;
+  float average;
+}rollingAverage;
+
+rollingAverage potRAValue;
+u_long lastmilis;
+uint8_t potValue;
+
+
 
 void setup() {
-  // put your setup code here, to run once:
-  int result = myFunction(2, 3);
+  Serial.begin(9600);
+  lastmilis = millis();
+  potValue = 0;
 }
 
 void loop() {
   // put your main code here, to run repeatedly:
-}
 
-// put function definitions here:
-int myFunction(int x, int y) {
-  return x + y;
+
+  potValue = getRawADCLeftPotentiometer();
+  potRAValue.avgSum -= potRAValue.data[potRAValue.index];
+  potRAValue.avgSum += potValue;
+  potRAValue.data[potRAValue.index] = potValue;
+  potRAValue.index++;
+  potRAValue.index %= RAWindowSize;
+
+  if(millis() - lastmilis > 5){
+    potRAValue.average = (float)(potRAValue.avgSum/RAWindowSize);
+    Serial.println(potRAValue.average);
+    lastmilis = millis();
+  }
+  
 }

--- a/Skip-Device/src/main.cpp
+++ b/Skip-Device/src/main.cpp
@@ -1,41 +1,43 @@
+/**
+ * @file main.cpp
+ * @author your name (you@domain.com)
+ * @author Graham Driver (driverg@myumanitoba.ca)
+ * @brief The main file of the skip device for the WEE Curl Skip Device.
+ * @version 0.1
+ * @date 2024-02-20
+ * 
+ * @copyright Copyright (c) 2024
+ * 
+ */
+
 #include <Arduino.h>
 #include "slidePotentiometersDriver.h"
 
-#define RAWindowSize    50
-
-typedef struct{
-  uint8_t index;
-  uint8_t data[RAWindowSize];
-  uint32_t avgSum;
-  float average;
-}rollingAverage;
-
-rollingAverage potRAValue;
 u_long lastmilis;
-uint8_t potValue;
-
-
+slider_t leftSlider;
+slider_t rightSlider;
+uint16_t leftAverage;
+uint16_t rightAverage;
+uint8_t leftPercentage;
+uint8_t rightPercentage;
 
 void setup() {
-  Serial.begin(9600);
+  Serial.begin(115200);
   lastmilis = millis();
-  potValue = 0;
+  leftSlider.pin = leftSliderPin;
+  rightSlider.pin = rightSliderPin;
 }
 
 void loop() {
-  // put your main code here, to run repeatedly:
-
-
-  potValue = getRawADCLeftPotentiometer();
-  potRAValue.avgSum -= potRAValue.data[potRAValue.index];
-  potRAValue.avgSum += potValue;
-  potRAValue.data[potRAValue.index] = potValue;
-  potRAValue.index++;
-  potRAValue.index %= RAWindowSize;
-
-  if(millis() - lastmilis > 5){
-    potRAValue.average = (float)(potRAValue.avgSum/RAWindowSize);
-    Serial.println(potRAValue.average);
+  //polling loop
+  pollSlider(&leftSlider);
+  pollSlider(&rightSlider);
+  if((millis() - lastmilis) > 100){
+    leftAverage = getAveragePotValue(&leftSlider);
+    rightAverage = getAveragePotValue(&rightSlider);
+    leftPercentage = getPercentagePotValue(&leftSlider);
+    rightPercentage = getPercentagePotValue(&rightSlider);
+    Serial.printf("Left Pot Value: %d, Left Pot Percentage: %d, Right Pot Value: %d, Right Pot Percentage: %d", leftAverage, leftPercentage, rightAverage, rightPercentage);
     lastmilis = millis();
   }
   

--- a/Skip-Device/src/slidePotentiometersDriver.cpp
+++ b/Skip-Device/src/slidePotentiometersDriver.cpp
@@ -15,14 +15,16 @@ SLIDE_POT_StatusTypeDef pollSlider(slider_t *slider){
     SLIDE_POT_StatusTypeDef status = SLIDE_POT_OK;
     uint16_t potValue;
 
-    //assert(slider.pin != NULL);
+    //assert(slider.pin != NULL); Some sort of error checking should be used in future.
 
     potValue = analogRead(slider->pin);
-    slider->avgSum -= slider->data[slider->index];
-    slider->avgSum += potValue;
-    slider->data[slider->index] = potValue;
-    slider->index++;
-    slider->index %= RAWindowSize;
+
+    // Moving Average Code
+    slider->avgSum -= slider->data[slider->index]; // Remove oldest value
+    slider->avgSum += potValue; // Add new value 
+    slider->data[slider->index] = potValue; // Set position to new value
+    slider->index++; // Increase index
+    slider->index %= RAWindowSize; // If index larger than window set to 1
 
     error:
         return status;

--- a/Skip-Device/src/slidePotentiometersDriver.cpp
+++ b/Skip-Device/src/slidePotentiometersDriver.cpp
@@ -1,8 +1,8 @@
 /**
  * @file slidePotentiometersDriver.cpp
- * @author Graham Driver (drivergraham1@gmail.com)
- * @brief This script contains functions to initialize and control the slide potentiometers connected to the WEE Curl Skip Device.
- * @version 0.1
+ * @author Graham Driver (driverg@myumanitoba.ca)
+ * @brief This script is used in order to poll the sliders of the the WEE Curl Skip Device.
+ * @version 0.2
  * @date 2024-02-18
  * 
  * @copyright Copyright (c) 2024
@@ -11,11 +11,28 @@
 
 #include "slidePotentiometersDriver.h"
 
+SLIDE_POT_StatusTypeDef pollSlider(slider_t *slider){
+    SLIDE_POT_StatusTypeDef status = SLIDE_POT_OK;
+    uint16_t potValue;
+
+    //assert(slider.pin != NULL);
+
+    potValue = analogRead(slider->pin);
+    slider->avgSum -= slider->data[slider->index];
+    slider->avgSum += potValue;
+    slider->data[slider->index] = potValue;
+    slider->index++;
+    slider->index %= RAWindowSize;
+
+    error:
+        return status;
+}
 
 
-uint8_t getRawADCLeftPotentiometer(void){
-    uint8_t analogValue;
+uint16_t getAveragePotValue(slider_t *slider){
+    return (uint16_t)(slider->avgSum / RAWindowSize);
+}
 
-    analogValue = analogRead(leftSlidePin);
-    return analogValue;
+uint8_t getPercentagePotValue(slider_t *slider){
+    return (uint8_t)((float)100 * ( (float)slider->avgSum / (float)RAWindowSize)/ (float)4096);
 }

--- a/Skip-Device/src/slidePotentiometersDriver.cpp
+++ b/Skip-Device/src/slidePotentiometersDriver.cpp
@@ -1,0 +1,21 @@
+/**
+ * @file slidePotentiometersDriver.cpp
+ * @author Graham Driver (drivergraham1@gmail.com)
+ * @brief This script contains functions to initialize and control the slide potentiometers connected to the WEE Curl Skip Device.
+ * @version 0.1
+ * @date 2024-02-18
+ * 
+ * @copyright Copyright (c) 2024
+ * 
+ */
+
+#include "slidePotentiometersDriver.h"
+
+
+
+uint8_t getRawADCLeftPotentiometer(void){
+    uint8_t analogValue;
+
+    analogValue = analogRead(leftSlidePin);
+    return analogValue;
+}


### PR DESCRIPTION
I finished the slider driver. 

It uses a struct called slider_t that contains all the information necessary for the moving average filter and the pin number of the given slider it can be seen in the second image.

```c++
typedef struct{
    uint8_t index = 0;            // Index of the moving average
    uint16_t data[RAWindowSize];  // Data from rolling average
    uint32_t avgSum = 0;          // Sum of values in data
    uint16_t pin = INT16_MAX;     // Pin of the slider
}slider_t;
``` 

Below you can see a couple functions, the pollSlider function is intended to be called in the main loop of the program in order to constantly update the rolling average of the potentiometers. The others are get functions that return the averaged ADC value of the sliders and the function returns the average value in a percentage format.
```c++
SLIDE_POT_StatusTypeDef pollSlider(slider_t *slider){
    SLIDE_POT_StatusTypeDef status = SLIDE_POT_OK;
    uint16_t potValue;

    //assert(slider.pin != NULL); Some sort of error checking should be used in future.

    potValue = analogRead(slider->pin);

    // Moving Average Code
    slider->avgSum -= slider->data[slider->index]; // Remove oldest value
    slider->avgSum += potValue; // Add new value 
    slider->data[slider->index] = potValue; // Set position to new value
    slider->index++; // Increase index
    slider->index %= RAWindowSize; // If index larger than window set to 1

    error:
        return status;
}


uint16_t getAveragePotValue(slider_t *slider){
    return (uint16_t)(slider->avgSum / RAWindowSize);
}

uint8_t getPercentagePotValue(slider_t *slider){
    return (uint8_t)((float)100 * ( (float)slider->avgSum / (float)RAWindowSize)/ (float)4096);
}
```

I also added some setup code and a section of how it would run into main. We can just add other pieces of code in main around in their own sections similar to what I did.