### PR TITLE
Skip device Pinout Definitions

### DIFF
--- a/Skip-Device/include/pinouts.h
+++ b/Skip-Device/include/pinouts.h
@@ -1,0 +1,29 @@
+/**
+ * @file pinouts.h
+ * @author Graham Driver (driverg@myumanitoba.ca)
+ * @brief Definitions of every used pin for the skip controller
+ * @version 0.1
+ * @date 2024-03-28
+ * 
+ * @copyright Copyright (c) 2024
+ * 
+ */
+
+// Sliders
+#define leftSliderPin   A0
+#define rightSliderPin  A13
+
+// LEDs
+#define indicatorLED    A14
+
+// Switches
+#define rightSwitchPinOne   A15
+#define rightSwitchPinTwo   A16
+#define rightSwitchPinThree A17
+#define leftSwitchPinOne    A28
+#define leftSwitchPinTwo    A29
+#define leftSwitchPinThree  A27
+
+// Buttons
+#define hurryHardButton     A26
+ 

--- a/Skip-Device/include/slidePotentiometersDriver.h
+++ b/Skip-Device/include/slidePotentiometersDriver.h
@@ -12,8 +12,6 @@
 #include <stdlib.h>
 
 #define RAWindowSize    100
-#define leftSliderPin   A0
-#define rightSliderPin  A13
 
 typedef struct{
     uint8_t index = 0;            // Index of the moving average

--- a/Skip-Device/src/main.cpp
+++ b/Skip-Device/src/main.cpp
@@ -12,6 +12,7 @@
 
 #include <Arduino.h>
 #include "slidePotentiometersDriver.h"
+#include "pinouts.h"
 
 // Slider Structs
 slider_t leftSlider;


### PR DESCRIPTION
I added a file to hold all pinout values called pinouts.h. I also removed my previous definitions in the slide pot header as it is now in the pinouts file.